### PR TITLE
Add artifacts to update references to the Carter NuGet package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+## Reusable bits
+
+This repository contains actions that can be reused in other repositories.
+
+It currently includes:
+
+- [A GitHub Actions workflow that can update references to the Carter NuGet package](./update-carter-package-references/README.md).

--- a/update-carter-package-references/README.md
+++ b/update-carter-package-references/README.md
@@ -1,0 +1,10 @@
+## Update Carter NuGet package references
+
+The files in this directory can help set up a workflow in other repositories to update references to the Carter NuGet package.
+
+### Steps
+
+1. Create a new branch in the target repository.
+1. Copy the [`workflow.yml`](./workflow.yml) file in this directory as the `.github/workflows/update-carter-package-references.yml` file in the target repository.
+1. Open a pull request.
+1. When merged, you will find a new action in the target repository.

--- a/update-carter-package-references/run.ps1
+++ b/update-carter-package-references/run.ps1
@@ -1,0 +1,94 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]
+    $RootDirectory,
+
+    [Parameter()]
+    [switch]
+    $IncludePrerelease
+)
+
+function Get-LatestCarterPackageVersion {
+    [CmdletBinding()]
+    param(
+        [Parameter()]
+        [switch]
+        $IncludePrerelease
+    )
+
+    #
+    # NuGet Server API docs
+    # https://learn.microsoft.com/en-us/nuget/api/overview
+    #
+
+    $nugetApiServiceIndexUrl = 'https://api.nuget.org/v3/index.json'
+    $serviceIndexResponse = Invoke-RestMethod -Method Get -Uri $nugetApiServiceIndexUrl
+
+    $nugetApiSearchQueryServiceUrl = $serviceIndexResponse.resources |
+        Where-Object '@type' -eq 'SearchQueryService' |
+        Select-Object -First 1 |
+        Select-Object -ExpandProperty '@id'
+
+    #
+    # https://learn.microsoft.com/en-us/nuget/api/search-query-service-resource#search-for-packages
+    #
+    $queryParameters = @{
+        q           = 'Carter'
+        prerelease  = if ($IncludePrerelease) { 'true' } else { 'false' }
+        semVerLevel = '2.0.0'
+    }
+
+    $searchResponse = Invoke-RestMethod `
+        -Method Get `
+        -Uri $nugetApiSearchQueryServiceUrl `
+        -Body $queryParameters
+
+    $latestPackage = $searchResponse.data |
+        Where-Object 'id' -eq 'Carter' |
+        Sort-Object -Property 'version' -Descending |
+        Select-Object -First 1
+
+    Write-Output -InputObject $latestPackage.version
+}
+
+function Update-CarterPackageReferences {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]
+        $RootDirectory,
+
+        [Parameter(Mandatory = $true)]
+        [string]
+        $PackageVersion
+    )
+
+    $projectFiles = Get-ChildItem `
+        -Path $RootDirectory `
+        -Recurse `
+        -File `
+        -Filter '*.csproj'
+
+    $regexPattern = '(?<beforeVersion><PackageReference\s+Include="Carter"\s+Version=")[\s\S]+?(?<afterVersion>"\s*/>)'
+
+    foreach ($projectFile in $projectFiles) {
+        $contents = Get-Content -Path $projectFile.FullName -Raw -Encoding utf8
+
+        if ([System.Text.RegularExpressions.Regex]::IsMatch($contents, $regexPattern)) {
+            $newContents = [System.Text.RegularExpressions.Regex]::Replace(
+                $contents,
+                $regexPattern,
+                ('${{beforeVersion}}{0}${{afterVersion}}' -f $PackageVersion))
+
+            Set-Content -Path $projectFile.FullName -Value $newContents -Encoding utf8 -NoNewline
+        }
+    }
+}
+
+if (-not (Test-Path -Path $RootDirectory -PathType Container)) {
+    throw ('Directory ''{0}'' does not exist' -f $RootDirectory)
+}
+
+$targetCarterPackageVersion = Get-LatestCarterPackageVersion -IncludePrerelease:$IncludePrerelease
+Update-CarterPackageReferences -RootDirectory $RootDirectory -PackageVersion $targetCarterPackageVersion

--- a/update-carter-package-references/workflow.yml
+++ b/update-carter-package-references/workflow.yml
@@ -1,0 +1,58 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Update Carter NuGet package references
+
+on:
+  workflow_dispatch:
+    inputs:
+      includePrerelease:
+        type: boolean
+        default: false
+        description: Whether to include prerelease versions when searching for the latest version of the Carter NuGet package
+
+      commitAndPush:
+        type: boolean
+        default: false
+        description: Whether to commit and push the changes; Useful to test the process by looking at the resulting Git diff
+
+jobs:
+  update-carter-package-references:
+    name: Update Carter NuGet package references
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check out this repository
+      uses: actions/checkout@v3
+      with:
+        path: self
+
+    - name: Check out the CarterCommunity/.github repository
+      uses: actions/checkout@v3
+      with:
+        repository: CarterCommunity/.github
+        path: .github
+
+    - name: Update package references with latest version from NuGet
+      run: >-
+        .github/update-carter-package-references/run.ps1
+        -RootDirectory (Join-Path -Path $env:GITHUB_WORKSPACE -ChildPath 'self')
+        -IncludePrerelease:$${{ github.event.inputs.includePrerelease }}
+      shell: pwsh
+
+    - name: Show Git diff
+      run: git diff
+
+    # https://github.com/marketplace/actions/checkout#push-a-commit-using-the-built-in-token
+    - if: github.event.inputs.commitAndPush
+      name: Commit changes and push if necessary
+      run: |
+        GIT_CHANGES=$(git status --porcelain)
+        if [ "$GIT_CHANGES" == "" ]; then
+          echo "No changes to commit"
+        else
+          echo "Committing and pushing changes"
+          git config user.name Jonathan Channon
+          git config user.email jonathan.channon@gmail.com
+          git add .
+          git commit -m "Update Carter NuGet package references"
+          git push
+        fi


### PR DESCRIPTION
Linked to https://github.com/CarterCommunity/Carter/issues/311.

This PR "extracts" the PowerShell script that goes through the `.csproj` files in a repo, and updates the references to the Cater NuGet package.

The next step is to update the `CarterCommunity/Carter` repository to use this script instead of the one in that repository.